### PR TITLE
fix: ensure the `ElectronicDensity` is always unrestricted-spin

### DIFF
--- a/qiskit_nature_pyscf/pyscf_ground_state_solver.py
+++ b/qiskit_nature_pyscf/pyscf_ground_state_solver.py
@@ -166,17 +166,10 @@ class PySCFGroundStateSolver(GroundStateSolver):
             nelec=problem.num_particles,
         )
 
-        density: ElectronicDensity
-        if restricted_spin:
-            raw_density = self.solver.make_rdm1(
-                ci_vec, norb=problem.num_spatial_orbitals, nelec=problem.num_particles
-            )
-            density = ElectronicDensity.from_raw_integrals(raw_density)
-        else:
-            raw_density = self.solver.make_rdm1s(
-                ci_vec, norb=problem.num_spatial_orbitals, nelec=problem.num_particles
-            )
-            density = ElectronicDensity.from_raw_integrals(raw_density[0], h1_b=raw_density[1])
+        raw_density = self.solver.make_rdm1s(
+            ci_vec, norb=problem.num_spatial_orbitals, nelec=problem.num_particles
+        )
+        density = ElectronicDensity.from_raw_integrals(raw_density[0], h1_b=raw_density[1])
 
         result = ElectronicStructureResult()
         result.computed_energies = np.asarray([energy])

--- a/releasenotes/notes/proper-qiskit-density-0582f26cc9a669d9.yaml
+++ b/releasenotes/notes/proper-qiskit-density-0582f26cc9a669d9.yaml
@@ -1,0 +1,10 @@
+---
+fixes:
+  - |
+    The :class:`~qiskit_nature.second_q.properties.ElectronicDensity` object that was returned as part of the
+    :class:`~qiskit_nature.second_q.problems.ElectronicStructureResult` from the :class:`.PySCFGroundStateSolver`
+    was faultily storing restricted-spin information within the alpha-spin register even though the object is
+    documented as storing unrestricted spin-data. This has been fixed and the
+    :class:`~qiskit_nature.second_q.properties.ElectronicDensity` object is now guaranteed to store
+    unrestricted-spin information. If a restricted-spin density is required it may be obtained from the
+    :meth:`~qiskit_nature.second_q.properties.ElectronicDensity.trace_spin` method.


### PR DESCRIPTION


<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

The `ElectronicDensity` object returned in the `ElectronicStructureResult` from the `PySCFGroundStateSolver` is documented to always contain unrestricted-spin information. This was not the case so far and is addressed by this commit.

### Details and comments


