### PR TITLE
feat: support nroots greater than 1

### DIFF
--- a/qiskit_nature_pyscf/pyscf_ground_state_solver.py
+++ b/qiskit_nature_pyscf/pyscf_ground_state_solver.py
@@ -166,22 +166,36 @@ class PySCFGroundStateSolver(GroundStateSolver):
             nelec=problem.num_particles,
         )
 
+        if not isinstance(energy, np.ndarray):
+            energy = [energy]
+
+        gs_vec = ci_vec
+        if isinstance(ci_vec, list):
+            gs_vec = ci_vec[0]
+
         raw_density = self.solver.make_rdm1s(
-            ci_vec, norb=problem.num_spatial_orbitals, nelec=problem.num_particles
+            gs_vec, norb=problem.num_spatial_orbitals, nelec=problem.num_particles
         )
         density = ElectronicDensity.from_raw_integrals(raw_density[0], h1_b=raw_density[1])
 
         result = ElectronicStructureResult()
-        result.computed_energies = np.asarray([energy])
+        result.computed_energies = np.asarray(energy)
         result.hartree_fock_energy = problem.reference_energy
         result.extracted_transformer_energies = dict(problem.hamiltonian.constants.items())
         result.nuclear_repulsion_energy = result.extracted_transformer_energies.pop(
             "nuclear_repulsion_energy", None
         )
-        result.num_particles = [sum(problem.num_particles)]
-        result.magnetization = [float("NaN")]
-        result.total_angular_momentum = [float("NaN")]
+        result.num_particles = [sum(problem.num_particles)] * len(energy)
+        result.magnetization = [float("NaN")] * len(energy)
+        result.total_angular_momentum = [float("NaN")] * len(energy)
+        # NOTE: the ElectronicStructureResult does not yet support multiple densities. Thus, we only
+        # have the ground-state density here, regardless of how many roots were computed.
         result.electronic_density = density
+
+        # TODO: we should figure out a way to include the `ci_vec` in the returned result. This
+        # would allow users to do additional computations themselves, if needed.
+        # This is likely pending improvements to the `Result` classes in Qiskit Nature. See for
+        # example: https://github.com/qiskit-community/qiskit-nature/issues/1198
 
         return result
 

--- a/releasenotes/notes/support-multiple-roots-24f3119f247ab6f2.yaml
+++ b/releasenotes/notes/support-multiple-roots-24f3119f247ab6f2.yaml
@@ -1,0 +1,6 @@
+---
+features:
+  - |
+    Support was added for ``FCISolver`` instances which have their ``nroots``
+    attribute set to a value higher than 1, indicating that they also compute
+    excited states.

--- a/test/test_pyscf_ground_state_solver.py
+++ b/test/test_pyscf_ground_state_solver.py
@@ -63,3 +63,28 @@ class TestPySCFGroundStateSolver(QiskitNaturePySCFTestCase):
         casci.run()
 
         self.assertAlmostEqual(casci.e_tot, result.total_energies[0])
+
+    def test_nroots_support(self):
+        """Test support for more than ground-state calculations."""
+        driver = PySCFDriver(
+            atom="H 0.0 0.0 0.0; H 0.0 0.0 1.5",
+            basis="sto3g",
+        )
+        problem = driver.run()
+
+        fci_solver = fci.direct_spin1.FCI()
+        fci_solver.nroots = 2
+        solver = PySCFGroundStateSolver(fci_solver)
+
+        result = solver.solve(problem)
+        print(result)
+
+        casci = mcscf.CASCI(driver._calc, 2, 2)
+        casci.fcisolver.nroots = 2
+        casci.run()
+
+        self.assertAlmostEqual(casci.e_tot[0], result.total_energies[0])
+        self.assertAlmostEqual(casci.e_tot[1], result.total_energies[1])
+        self.assertEqual(len(result.num_particles), 2)
+        self.assertEqual(len(result.magnetization), 2)
+        self.assertEqual(len(result.total_angular_momentum), 2)


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

This adds support for `nroots > 1` to the `PySCFGroundStateSolver`.
Technically, this would make it an `ExcitedStatesSolver`, but I do not think that differentiating this interface adds any value and is therefore unnecessary complexity.

### Details and comments


