### PR TITLE
Compute S^z and S^2

### DIFF
--- a/.pylintdict
+++ b/.pylintdict
@@ -47,3 +47,4 @@ tuple
 tuples
 vec
 vqe
+wavefunction

--- a/qiskit_nature_pyscf/pyscf_ground_state_solver.py
+++ b/qiskit_nature_pyscf/pyscf_ground_state_solver.py
@@ -167,7 +167,7 @@ class PySCFGroundStateSolver(GroundStateSolver):
         )
 
         if not isinstance(energy, np.ndarray):
-            # computed a single root, but in the following we pretent to always have multiple ones
+            # computed a single root, but in the following we pretend to always have multiple ones
             energy = [energy]
             ci_vec = [ci_vec]
 

--- a/qiskit_nature_pyscf/pyscf_ground_state_solver.py
+++ b/qiskit_nature_pyscf/pyscf_ground_state_solver.py
@@ -167,16 +167,28 @@ class PySCFGroundStateSolver(GroundStateSolver):
         )
 
         if not isinstance(energy, np.ndarray):
+            # computed a single root, but in the following we pretent to always have multiple ones
             energy = [energy]
-
-        gs_vec = ci_vec
-        if isinstance(ci_vec, list):
-            gs_vec = ci_vec[0]
+            ci_vec = [ci_vec]
 
         raw_density = self.solver.make_rdm1s(
-            gs_vec, norb=problem.num_spatial_orbitals, nelec=problem.num_particles
+            ci_vec[0], norb=problem.num_spatial_orbitals, nelec=problem.num_particles
         )
         density = ElectronicDensity.from_raw_integrals(raw_density[0], h1_b=raw_density[1])
+
+        overlap_ab: np.ndarray | None = None
+        if problem.properties.angular_momentum is not None:
+            overlap_ab = problem.properties.angular_momentum.overlap
+
+        magnetization: list[float] = []
+        angular_momentum: list[float] = []
+        for vec in ci_vec:
+            densities = self.solver.make_rdm12s(
+                vec, norb=problem.num_spatial_orbitals, nelec=problem.num_particles
+            )
+            spin_square, spin_z = self._compute_spin(densities, overlap_ab)
+            magnetization.append(spin_z)
+            angular_momentum.append(spin_square)
 
         result = ElectronicStructureResult()
         result.computed_energies = np.asarray(energy)
@@ -186,8 +198,8 @@ class PySCFGroundStateSolver(GroundStateSolver):
             "nuclear_repulsion_energy", None
         )
         result.num_particles = [sum(problem.num_particles)] * len(energy)
-        result.magnetization = [float("NaN")] * len(energy)
-        result.total_angular_momentum = [float("NaN")] * len(energy)
+        result.magnetization = magnetization
+        result.total_angular_momentum = angular_momentum
         # NOTE: the ElectronicStructureResult does not yet support multiple densities. Thus, we only
         # have the ground-state density here, regardless of how many roots were computed.
         result.electronic_density = density
@@ -214,3 +226,42 @@ class PySCFGroundStateSolver(GroundStateSolver):
     def solver(self) -> fci.direct_spin1.FCISolver:
         """Returns the solver."""
         return self._solver
+
+    @staticmethod
+    def _compute_spin(
+        densities: tuple[tuple[np.ndarray, np.ndarray], tuple[np.ndarray, np.ndarray, np.ndarray]],
+        overlap_ab: np.ndarray | None,
+    ):
+        (dm1a, dm1b), (dm2aa, dm2ab, dm2bb) = densities
+
+        identity = np.eye(dm1a.shape[0])
+        if overlap_ab is None:
+            overlap_ab = identity
+
+        overlap_ba = overlap_ab.T
+
+        # NOTE: we know for a fact, that overlap_aa and overlap_bb will always equal the identity
+        # when dealing with a single wavefunction
+        ssz = (
+            np.einsum("ijkl,ij,kl->", dm2aa, identity, identity)
+            - np.einsum("ijkl,ij,kl->", dm2ab, identity, identity)
+            + np.einsum("ijkl,ij,kl->", dm2bb, identity, identity)
+            - np.einsum("ijkl,ij,kl->", dm2ab, identity, identity)
+            + np.einsum("ji,ij->", dm1a, identity)
+            + np.einsum("ji,ij->", dm1b, identity)
+        ) * 0.25
+
+        dm2abba = -dm2ab.transpose(0, 3, 2, 1)  # alpha^+ beta^+ alpha beta
+        dm2baab = -dm2ab.transpose(2, 1, 0, 3)  # beta^+ alpha^+ beta alpha
+        ssxy = (
+            np.einsum("ijkl,ij,kl->", dm2abba, overlap_ab, overlap_ba)
+            + np.einsum("ijkl,ij,kl->", dm2baab, overlap_ba, overlap_ab)
+            # NOTE: the following two lines are different from PySCF because we may deal with
+            # non-unitary overlap_ab matrices
+            + np.einsum("ji,ij->", dm1a, overlap_ab @ overlap_ba)
+            + np.einsum("ji,ij->", dm1b, overlap_ba @ overlap_ab)
+        ) * 0.5
+
+        spin_square = ssxy + ssz
+
+        return spin_square, np.sqrt(ssz)

--- a/qiskit_nature_pyscf/pyscf_ground_state_solver.py
+++ b/qiskit_nature_pyscf/pyscf_ground_state_solver.py
@@ -192,11 +192,6 @@ class PySCFGroundStateSolver(GroundStateSolver):
         # have the ground-state density here, regardless of how many roots were computed.
         result.electronic_density = density
 
-        # TODO: we should figure out a way to include the `ci_vec` in the returned result. This
-        # would allow users to do additional computations themselves, if needed.
-        # This is likely pending improvements to the `Result` classes in Qiskit Nature. See for
-        # example: https://github.com/qiskit-community/qiskit-nature/issues/1198
-
         return result
 
     def get_qubit_operators(

--- a/releasenotes/notes/compute-spin-square-18c5c4678551f7be.yaml
+++ b/releasenotes/notes/compute-spin-square-18c5c4678551f7be.yaml
@@ -1,0 +1,14 @@
+---
+features:
+  - |
+    The :class:`.PySCFGroundStateSolver` now also computes the magnetization ($S^z$)
+    and total angular momentum ($S^2$) values for all computes roots. In doing so,
+    it properly takes the alpha-beta overlap matrix from the
+    ``qiskit_nature.second_q.properties.AngularMomentum.overlap`` property into account.
+    When this overlap is non-unitary, the spin-contamination within the active subspace
+    is computed correctly. For more details, see also:
+
+    * <https://github.com/qiskit-community/qiskit-nature/issues/1273>_
+    * <https://github.com/qiskit-community/qiskit-nature/pull/1275>_
+    * <https://github.com/qiskit-community/qiskit-nature/issues/1291>_
+    * <https://github.com/qiskit-community/qiskit-nature/pull/1292>_

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-qiskit-nature>=0.7
+qiskit-nature>=0.7.1
 pyscf>=2.0

--- a/test/test_pyscf_ground_state_solver.py
+++ b/test/test_pyscf_ground_state_solver.py
@@ -40,6 +40,8 @@ class TestPySCFGroundStateSolver(QiskitNaturePySCFTestCase):
         casci.run()
 
         self.assertAlmostEqual(casci.e_tot, result.total_energies[0])
+        self.assertAlmostEqual(result.magnetization[0], 0.0)
+        self.assertAlmostEqual(result.total_angular_momentum[0], 0.0)
 
     def test_direct_uhf_fci(self):
         """Test with the ``fci.direct_uhf.FCISolver``."""
@@ -63,6 +65,8 @@ class TestPySCFGroundStateSolver(QiskitNaturePySCFTestCase):
         casci.run()
 
         self.assertAlmostEqual(casci.e_tot, result.total_energies[0])
+        self.assertAlmostEqual(result.magnetization[0], 1.0)
+        self.assertAlmostEqual(result.total_angular_momentum[0], 1.99988454)
 
     def test_nroots_support(self):
         """Test support for more than ground-state calculations."""
@@ -77,7 +81,6 @@ class TestPySCFGroundStateSolver(QiskitNaturePySCFTestCase):
         solver = PySCFGroundStateSolver(fci_solver)
 
         result = solver.solve(problem)
-        print(result)
 
         casci = mcscf.CASCI(driver._calc, 2, 2)
         casci.fcisolver.nroots = 2
@@ -85,6 +88,9 @@ class TestPySCFGroundStateSolver(QiskitNaturePySCFTestCase):
 
         self.assertAlmostEqual(casci.e_tot[0], result.total_energies[0])
         self.assertAlmostEqual(casci.e_tot[1], result.total_energies[1])
-        self.assertEqual(len(result.num_particles), 2)
-        self.assertEqual(len(result.magnetization), 2)
-        self.assertEqual(len(result.total_angular_momentum), 2)
+        self.assertAlmostEqual(result.num_particles[0], 2.0)
+        self.assertAlmostEqual(result.num_particles[1], 2.0)
+        self.assertAlmostEqual(result.magnetization[0], 0.0)
+        self.assertAlmostEqual(result.magnetization[1], 0.0)
+        self.assertAlmostEqual(result.total_angular_momentum[0], 0.0)
+        self.assertAlmostEqual(result.total_angular_momentum[1], 2.0)


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

After multiple fixes in Qiskit Nature, this PR now also adds support for computing `S^z` and `S^2` in the `PySCFGroundStateSolver`.

### Details and comments

Supporting the correct `AngularMomentum` with taking the alpha-beta overlap into account during the `QiskitSolver` is currently not possible because of the API workflow. In other words: the `kernel` method is not provided the information from which we can reconstruct this overlap matrix during the construction of the `AngularMomentum` property.
We also cannot really compute it up-front and inject it into the `QiskitSolver` as an attribute, because this would require a-priori knowledge of the active MOs (which we do not have at that point).

This will need to be sorted together with the PySCF team, once I have raised the problem discussed [here](https://github.com/qiskit-community/qiskit-nature/issues/1291#issuecomment-1836417011) to them, since this affects their UCASCI and UCASSCF methods, too.
