### PR TITLE
Update intersphinx links and others

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ cas.run()
 More detailed documentation can be found at
 [Documentation](https://qiskit-community.github.io/qiskit-nature-pyscf/). For more detailed 
 explanations we recommend to check out the documentation of
-[PySCF](https://pyscf.org/) and [Qiskit Nature](https://qiskit.org/ecosystem/nature/).
+[PySCF](https://pyscf.org/) and [Qiskit Nature](https://qiskit-community.github.io/qiskit-nature/).
 
 
 ## Citation

--- a/README.md
+++ b/README.md
@@ -79,9 +79,9 @@ cas.fcisolver = QiskitSolver(algorithm)
 cas.run()
 ```
 
-More detailed documentation can be found at
-[Documentation](https://qiskit-community.github.io/qiskit-nature-pyscf/). For more detailed 
-explanations we recommend to check out the documentation of
+More detailed information for this plugin can be found in its
+[Documentation](https://qiskit-community.github.io/qiskit-nature-pyscf/). For further 
+information and explanations we recommend to check out the documentation of
 [PySCF](https://pyscf.org/) and [Qiskit Nature](https://qiskit-community.github.io/qiskit-nature/).
 
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,6 +1,6 @@
 # This code is part of a Qiskit project.
 #
-# (C) Copyright IBM 2022, 2023.
+# (C) Copyright IBM 2022, 2024.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory
@@ -174,9 +174,9 @@ intersphinx_mapping = {
     "python": ("https://docs.python.org/3", None),
     "numpy": ("https://numpy.org/doc/stable", None),
     "scipy": ("https://docs.scipy.org/doc/scipy", None),
-    "qiskit_algorithms": ("https://qiskit.org/ecosystem/algorithms", None),
-    "qiskit_nature": ("https://qiskit.org/ecosystem/nature", None),
-    "qiskit": ("https://qiskit.org/documentation", None),
+    "qiskit_algorithms": ("https://qiskit-community.github.io/qiskit-algorithms", None),
+    "qiskit_nature": ("https://qiskit-community.github.io/qiskit-nature", None),
+    "qiskit": ("https://docs.quantum.ibm.com/api/qiskit", None),
 }
 
 html_context = {"analytics_enabled": True}

--- a/qiskit_nature_pyscf/pyscf_ground_state_solver.py
+++ b/qiskit_nature_pyscf/pyscf_ground_state_solver.py
@@ -1,6 +1,6 @@
 # This code is part of a Qiskit project.
 #
-# (C) Copyright IBM 2023.
+# (C) Copyright IBM 2023, 2024.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory
@@ -72,8 +72,8 @@ class PySCFGroundStateSolver(GroundStateSolver):
        result = solver.solve(problem)
        print(result)
 
-    For more details please to the documentation of [PySCF](https://pyscf.org/) and
-    [Qiskit Nature](https://qiskit.org/ecosystem/nature/).
+    For more details please to the documentation of `PySCF <https://pyscf.org/>`_ and
+    `Qiskit Nature <https://qiskit-community.github.io/qiskit-nature/>`_.
     """
 
     def __init__(self, solver: fci.direct_spin1.FCISolver) -> None:

--- a/qiskit_nature_pyscf/qiskit_solver.py
+++ b/qiskit_nature_pyscf/qiskit_solver.py
@@ -1,6 +1,6 @@
 # This code is part of a Qiskit project.
 #
-# (C) Copyright IBM 2022, 2023.
+# (C) Copyright IBM 2022, 2024.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory
@@ -90,8 +90,8 @@ class QiskitSolver:
 
         cas.run()
 
-    For more details please to the documentation of [PySCF](https://pyscf.org/) and
-    [Qiskit Nature](https://qiskit.org/ecosystem/nature/).
+    For more details please to the documentation of `PySCF <https://pyscf.org/>`_ and
+    `Qiskit Nature <https://qiskit-community.github.io/qiskit-nature/>`_.
 
     An instance of this class has the following attributes:
 


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Updates links away from qiskit.org to the new locations for the docs

Fixes #51
Fixes #52

I also changed the link formatting in the two py files as it has the `[text](url)` format that looks like it was copied from the readme markdown and not updated. It came out as

![image](https://github.com/qiskit-community/qiskit-nature-pyscf/assets/40241007/c866af3e-0aef-4b15-b9af-7ac73f7cf768)

and now it comes out just as links

![image](https://github.com/qiskit-community/qiskit-nature-pyscf/assets/40241007/54dc43ab-33db-419f-8bb9-852dbe959ce7)

which I imagine was probably the desired outcome originally.

### Details and comments


Now that all the applications and the algorithms docs are deployed on github pages this updates the intersphinx links, in conf.py, and also urls that are coded directly in other places such as the readme and tutorials.

Note that the current theme is still emitting a link to qiskit.org/ecosystem, but that will get redirected for now until such time as Qiskit/qiskit_sphinx_theme#588 is resolved and new docs are generated with such an updated theme and re-deployed.
