### PR TITLE
Changed to install qiskit not qiskit-terra

### DIFF
--- a/.github/actions/install-main-dependencies/action.yml
+++ b/.github/actions/install-main-dependencies/action.yml
@@ -19,8 +19,8 @@ inputs:
   python-version:
     description: 'Python version'
     required: true
-  terra-main:
-    description: 'Use Terra main'
+  qiskit-main:
+    description: 'Use Qiskit main'
     required: true
   nature-main:
     description: 'Use Nature main'
@@ -30,17 +30,17 @@ runs:
   steps:
     - name: Get main last commit ids
       run: |
-        echo "TERRA_HASH=$(git ls-remote --heads https://github.com/Qiskit/qiskit-terra.git refs/heads/main  | awk '{print $1}')" >> $GITHUB_ENV
+        echo "QISKIT_HASH=$(git ls-remote --heads https://github.com/Qiskit/qiskit.git refs/heads/main  | awk '{print $1}')" >> $GITHUB_ENV
         echo "NATURE_HASH=$(git ls-remote --heads https://github.com/Qiskit/qiskit-nature.git refs/heads/main  | awk '{print $1}')" >> $GITHUB_ENV
       shell: bash
-    - name: Terra Cache
+    - name: Qiskit Cache
       env:
         CACHE_VERSION: v1
-      id: terra-cache
+      id: qiskit-cache
       uses: actions/cache@v3
       with:
-        path: terra-cache
-        key: terra-cache-${{ inputs.os }}-${{ inputs.python-version }}-${{ env.TERRA_HASH }}-${{ env.CACHE_VERSION }}
+        path: qiskit-cache
+        key: qiskit-cache-${{ inputs.os }}-${{ inputs.python-version }}-${{ env.QISKIT_HASH }}-${{ env.CACHE_VERSION }}
     - name: Nature Cache
       env:
         CACHE_VERSION: v1
@@ -49,15 +49,15 @@ runs:
       with:
         path: nature-cache
         key: nature-cache-${{ inputs.os }}-${{ inputs.python-version }}-${{ env.NATURE_HASH }}-${{ env.CACHE_VERSION }}
-    - name: Install Terra
+    - name: Install Qiskit
       env:
         MACOSX_DEPLOYMENT_TARGET: 10.15
       run: |
-        if [ "${{ inputs.terra-main }}" == "true" ]; then
-          echo 'Install Terra from Main'
-          BASE_DIR=terra-cache
+        if [ "${{ inputs.qiskit-main }}" == "true" ]; then
+          echo 'Install Qiskit from Main'
+          BASE_DIR=qiskit-cache
           build_from_main=true
-          cache_hit=${{ steps.terra-cache.outputs.cache-hit }}
+          cache_hit=${{ steps.qiskit-cache.outputs.cache-hit }}
           echo "cache hit: ${cache_hit}"
           if [ "$cache_hit" == "true" ]; then
             pip_result=0
@@ -73,19 +73,19 @@ runs:
           if [ "$build_from_main" == "true" ]; then
             echo 'Create wheel file from main'
             pip install -U wheel setuptools_rust
-            git clone --depth 1 --branch main https://github.com/Qiskit/qiskit-terra.git /tmp/qiskit-terra
-            pushd /tmp/qiskit-terra
+            git clone --depth 1 --branch main https://github.com/Qiskit/qiskit.git /tmp/qiskit
+            pushd /tmp/qiskit
             python setup.py bdist_wheel
             popd
-            cp -rf /tmp/qiskit-terra/dist/*.whl "${BASE_DIR}"
+            cp -rf /tmp/qiskit/dist/*.whl "${BASE_DIR}"
             pushd "${BASE_DIR}"
             python -m pip install *.whl
             popd
             pip uninstall -y setuptools_rust
           fi
         else
-          echo 'Install Terra from Stable'
-          pip install -U qiskit-terra
+          echo 'Install Qiskit from Stable'
+          pip install -U qiskit
         fi
       shell: bash
     - name: Install Nature from Main

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -1,6 +1,6 @@
 # This code is part of a Qiskit project.
 #
-# (C) Copyright IBM 2022, 2023.
+# (C) Copyright IBM 2022, 2024.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory
@@ -44,7 +44,7 @@ jobs:
         if: ${{ !startsWith(github.ref, 'refs/heads/stable') && !startsWith(github.base_ref, 'stable/') }}
       - name: Install Dependencies
         run: |
-          pip install jupyter qiskit-terra[visualization]
+          pip install jupyter qiskit[visualization]
           sudo apt-get install -y pandoc graphviz
         shell: bash
       - uses: ./.github/actions/install-nature-pyscf

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -65,7 +65,7 @@ jobs:
           os: ${{ matrix.os }}
       - name: Install Dependencies
         run: |
-          pip install jupyter qiskit-terra[visualization]
+          pip install jupyter qiskit[visualization]
           sudo apt-get -y install pandoc graphviz
           sudo apt-get -y install python3-enchant
           sudo apt-get -y install hunspell-en-us
@@ -134,7 +134,7 @@ jobs:
         with:
           os: ${{ matrix.os }}
           python-version: ${{ matrix.python-version }}
-          terra-main: "false"
+          qiskit-main: "false"
           nature-main: "false"
         if: ${{ !startsWith(github.ref, 'refs/heads/stable') && !startsWith(github.base_ref, 'stable/') }}
       - uses: ./.github/actions/install-nature-pyscf


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

It seems the CI actions and workflows had not been updated and still referred to and installed qiskit-terra. That is no longer part of Qiskit 1.0 and so it installed a pre-1.0 version where qiskit-terra was still there. Later it ended up installing Qiskit 1.0 and with both in the same environment things failed.

I changed the actions to no longer refer to anything as Terra and install Qiskit only.


### Details and comments

Probably want to backport this to keep the stable branch running too.
