### PR TITLE
Update intersphinx mapping and other URLs pointing to IQP Classic

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -176,7 +176,7 @@ intersphinx_mapping = {
     "scipy": ("https://docs.scipy.org/doc/scipy", None),
     "qiskit_algorithms": ("https://qiskit-community.github.io/qiskit-algorithms", None),
     "qiskit_nature": ("https://qiskit-community.github.io/qiskit-nature", None),
-    "qiskit": ("https://docs.quantum.ibm.com/api/qiskit", None),
+    "qiskit": ("https://quantum.cloud.ibm.com/docs/api/qiskit", None),
 }
 
 html_context = {"analytics_enabled": True}

--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -8,7 +8,7 @@ Installation
 ============
 
 Qiskit Nature PySCF depends on the main Qiskit package which has its own
-`installation instructions <https://docs.quantum.ibm.com/start/install>`__ detailing the
+`installation instructions <https://quantum.cloud.ibm.com/docs/guides/install-qiskit>`__ detailing the
 installation options for Qiskit and its supported environments/platforms. You should refer to
 that first. Then the information here can be followed which focuses on the additional installation
 specific to Qiskit Nature PySCF.
@@ -31,7 +31,7 @@ specific to Qiskit Nature PySCF.
 
        Since Qiskit Nature PySCF depends on Qiskit, and its latest changes may require new or changed
        features of Qiskit, you should first follow Qiskit's `"Install from source"` instructions
-       `here <https://docs.quantum.ibm.com/start/install-qiskit-source>`__
+       `here <https://quantum.cloud.ibm.com/docs/guides/install-qiskit-source>`__
 
        .. raw:: html
 


### PR DESCRIPTION
The documentation source of truth is moving to https://quantum.cloud.ibm.com/.